### PR TITLE
Add `output_source_file` input variable

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -31,6 +31,10 @@ inputs:
   output_text:
     description: Details (body) of the check run with a maximum of 65535 characters (markdown supported)
     required: false
+  output_source_file:
+    description: Path to a file containing the output to be used instead of using `output_text`). Only used if `output_text` is not set.
+    required: false
+    default: ''
   output_annotations:
     description: Information from your analysis to specific lines of code. Input must be in a JSON list format.
     required: false

--- a/dist/index.js
+++ b/dist/index.js
@@ -12720,7 +12720,7 @@ async function run() {
     var outputTitle = core.getInput("output_title")
     var outputSummary = core.getInput("output_summary")
 
-    var outText = core.getInput("output_text") != "" ? core.getInput("output_text") : external_fs_.readFileSync(core.getInput("output_source_file"), 'utf8')
+    var outputText = core.getInput("output_text") != "" ? core.getInput("output_text") : external_fs_.readFileSync(core.getInput("output_source_file"), 'utf8')
 
     var outputAnnotations = core.getInput("output_annotations")
     if (outputAnnotations != "") {

--- a/dist/index.js
+++ b/dist/index.js
@@ -12698,7 +12698,10 @@ function parseJson(string, reviver, filename) {
 	}
 }
 
+// EXTERNAL MODULE: external "fs"
+var external_fs_ = __nccwpck_require__(7147);
 ;// CONCATENATED MODULE: ./main.js
+
 
 
 
@@ -12716,7 +12719,9 @@ async function run() {
     var conclusion = core.getInput("conclusion")
     var outputTitle = core.getInput("output_title")
     var outputSummary = core.getInput("output_summary")
-    var outputText = core.getInput("output_text")
+
+    var outText = core.getInput("output_text") != "" ? core.getInput("output_text") : external_fs_.readFileSync(core.getInput("output_source_file"), 'utf8')
+
     var outputAnnotations = core.getInput("output_annotations")
     if (outputAnnotations != "") {
       outputAnnotations = parseJson(core.getInput("output_annotations"))
@@ -12743,7 +12748,7 @@ async function run() {
         output: {
           title: outputTitle,
           summary: outputSummary,
-          text: outputText,
+          text: outText,
           annotations: outputAnnotations,
           images: outputImages
         },

--- a/main.js
+++ b/main.js
@@ -17,7 +17,7 @@ async function run() {
     var outputTitle = core.getInput("output_title")
     var outputSummary = core.getInput("output_summary")
 
-    var outText = core.getInput("output_text") != "" ? core.getInput("output_text") : fs.readFileSync(core.getInput("output_source_file"), 'utf8')
+    var outputText = core.getInput("output_text") != "" ? core.getInput("output_text") : fs.readFileSync(core.getInput("output_source_file"), 'utf8')
 
     var outputAnnotations = core.getInput("output_annotations")
     if (outputAnnotations != "") {

--- a/main.js
+++ b/main.js
@@ -1,6 +1,7 @@
 import * as core from '@actions/core'
 import * as github from '@actions/github'
-import parseJson from 'parse-json';
+import parseJson from 'parse-json'
+import * as fs from 'fs'
 
 async function run() {
   try {
@@ -15,7 +16,9 @@ async function run() {
     var conclusion = core.getInput("conclusion")
     var outputTitle = core.getInput("output_title")
     var outputSummary = core.getInput("output_summary")
-    var outputText = core.getInput("output_text")
+
+    var outText = core.getInput("output_text") != "" ? core.getInput("output_text") : fs.readFileSync(core.getInput("output_source_file"), 'utf8')
+
     var outputAnnotations = core.getInput("output_annotations")
     if (outputAnnotations != "") {
       outputAnnotations = parseJson(core.getInput("output_annotations"))
@@ -42,7 +45,7 @@ async function run() {
         output: {
           title: outputTitle,
           summary: outputSummary,
-          text: outputText,
+          text: outText,
           annotations: outputAnnotations,
           images: outputImages
         },


### PR DESCRIPTION
## ℹ️ Type of change

Improvement

## 📄 Description

Add `output_source_file` input variable so larger content can be passed to the action .

## 🔎 How to test or reproduce

Usage:

```
      - name: Record check
        uses: marcelocarlos/check-run-action@add-output-src-file
        with:
          token: ${{ secrets.GITHUB_TOKEN }}
          name: test
          conclusion: success
          status: completed
          output_title: test title
          output_summary: summary
          output_source_file: /tmp/diff.txt
```

## 📝 Checklist

- [x] I have tested my changes
- [x] I have updated the documentation accordingly
- [x] I have considered and documented any potential impact of my changes on accessibility, security and performance
